### PR TITLE
feat(Song-detail): Add Song Details preview page

### DIFF
--- a/client/components/SongCreate.js
+++ b/client/components/SongCreate.js
@@ -18,7 +18,7 @@ class SongCreate extends Component {
             variables: {
                 title: this.state.title
             },
-            refetchQueries: [{ query }]
+            refetchQueries: [{ query }] // Re-executes the given query/queries in arguments
         }).then(() => { hashHistory.push('/') })
     }
 

--- a/client/components/SongDetail.js
+++ b/client/components/SongDetail.js
@@ -1,0 +1,13 @@
+import React, { Component } from 'react';
+
+class SongDetail extends Component {
+    render() {
+        return (
+            <div>
+                <h3>Song Detail</h3>
+            </div>
+        );
+    }
+}
+
+export default SongDetail;

--- a/client/components/SongList.js
+++ b/client/components/SongList.js
@@ -6,7 +6,8 @@ import query from '../queries/fetchSongs';
 
 class SongList extends Component {
     onSongDelete(id) {
-        this.props.mutate({ variables: { id } });
+        this.props.mutate({ variables: { id } })
+            .then(() => this.props.data.refetch()); // Re-execute the queries which are associated with SongList component. `graphql(query)` in here.
     }
 
     renderSongs() {

--- a/client/index.js
+++ b/client/index.js
@@ -1,3 +1,4 @@
+import './style/style.css';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Router, Route, hashHistory, IndexRoute } from 'react-router';
@@ -7,6 +8,7 @@ import { ApolloProvider } from 'react-apollo';
 import App from './components/App';
 import SongList from './components/SongList';
 import SongCreate from './components/SongCreate';
+import SongDetail from './components/SongDetail';
 
 const client = new ApolloClient({});
 
@@ -17,6 +19,7 @@ const Root = () => {
         		<Route path="/" component={App}>
           			<IndexRoute component={SongList} />
                     <Route path="songs/new" component={SongCreate}></Route>
+					<Route path="songs/:id" component={SongDetail}></Route>
         		</Route>
       		</Router>
     	</ApolloProvider>

--- a/client/queries/fetchSong.js
+++ b/client/queries/fetchSong.js
@@ -1,0 +1,10 @@
+import gql from 'graphql-tag';
+
+export default gql`
+    query SongQuery($id: ID!) {
+        song(id: $id) {
+            id,
+            title
+        }
+    }
+`;

--- a/client/style/style.css
+++ b/client/style/style.css
@@ -1,0 +1,8 @@
+.collection-item {
+    display: flex;
+    justify-content: space-between;
+}
+
+.material-icons {
+    cursor: pointer;
+}

--- a/server/schema/mutations.js
+++ b/server/schema/mutations.js
@@ -39,7 +39,7 @@ const mutation = new GraphQLObjectType({
       type: SongType,
       args: { id: { type: GraphQLID } },
       resolve(parentValue, { id }) {
-        return Song.remove({ _id: id });
+        return Song.deleteOne({ _id: id });
       }
     }
   }


### PR DESCRIPTION
Refetched song list after deleting a song. Added some styles to song list page and delete icon. Added a route for song detail page. Replaced a deprecated method in mutations. Added query to fetch song details from GraphQL server.